### PR TITLE
Remove auth token header from guest requests

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,10 +20,18 @@ const httpLink = createHttpLink({
 const authLink = setContext((_, { headers }) => {
   const token = localStorage.getItem('token');
 
+  if (token) {
+    return {
+      headers: {
+        ...headers,
+        authorization: token,
+      },
+    };
+  }
+
   return {
     headers: {
       ...headers,
-      authorization: token ? `${token}` : null,
     },
   };
 });


### PR DESCRIPTION
# Description

Remove the authorization header from all requests to the GraphQL endpoint that do not require authorization. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status

- [x] Complete, tested, ready to review and merge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
